### PR TITLE
User model, SingupSerializer 수정

### DIFF
--- a/soundhub/users/models.py
+++ b/soundhub/users/models.py
@@ -6,7 +6,7 @@ from django.db import models
 # 회원 가입시 이메일, 닉네임, 악기, 비밀번호를 받도록 하는 커스텀 매니저 설정
 class CustomUserManager(BaseUserManager):
     # 유저 생성 공통 메서드
-    def _create_user(self, email, nickname, password, is_staff, is_superuser, instrument=None):
+    def _create_user(self, email, nickname, password, is_staff=False, is_superuser=False, instrument=None):
         # 이메일을 입력하지 않은 경우 에러 발생
         if not email:
             raise ValueError('이메일을 반드시 입력해야 합니다.')
@@ -49,8 +49,6 @@ class CustomUserManager(BaseUserManager):
             email=email,
             nickname=nickname,
             password=password,
-            is_staff=False,
-            is_superuser=False,
             instrument=instrument,
         )
         return user
@@ -69,26 +67,17 @@ class User(AbstractBaseUser, PermissionsMixin):
     # 닉네임
     nickname = models.CharField(max_length=50, unique=True)
 
-    # 악기 선택지
-    INSTRUMENT_CHOICES = (
-        ('G', 'Guitar'),
-        ('B', 'Base'),
-        ('D', 'Drums'),
-        ('V', 'Vocals'),
-        ('K', 'Keyboard'),
-        ('O', 'Others'),
-    )
-    # 사용 악기
-    instrument = models.CharField(max_length=1,
-                                  choices=INSTRUMENT_CHOICES,
-                                  blank=True,
-                                  null=True)
+    # Guitar, Base, Drum, Vocal, Keyboard, Other 등은 프론트에서 체크박스 value 로 받고,
+    # Serializer 에서 문자열로 합쳐줌
+    instrument = models.TextField(blank=True, null=True)
 
     # 관리자 여부
     is_staff = models.BooleanField(default=False)
 
     # 활성화 여부
     is_active = models.BooleanField(default=True)
+    # 활성화 여부를 판단할 해쉬 값
+    activation_key = models.CharField(max_length=40)
 
     # 이메일을 유저네임으로 설정
     USERNAME_FIELD = 'email'
@@ -113,7 +102,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         return self.nickname
 
     def has_perm(self, perm, obj=None):
-        "Does the user have a specific permission?"
+        """Does the user have a specific permission?"""
         return True
 
     def has_module_perms(self, app_label):

--- a/soundhub/users/serializers.py
+++ b/soundhub/users/serializers.py
@@ -1,7 +1,7 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 
-from users.models import User
-
+User = get_user_model()
 
 # 유저 모델 시리얼라이저
 class UserSerializer(serializers.ModelSerializer):

--- a/soundhub/users/serializers.py
+++ b/soundhub/users/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 User = get_user_model()
 
+
 # 유저 모델 시리얼라이저
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
@@ -34,17 +35,21 @@ class SignupSerializer(serializers.ModelSerializer):
             'password2',
         )
 
+    # 악기를 여러개 받을 수 있어야 한다
+    # 여러 체크박스를 통해 'instrument' 이름으로 여러 값이 올때, list 형태로 온다는 것을 이용한다
+    # instrument list 를 ','로 구분된 문자열로 변환한다
+    def validate_instrument(self, data):
+        data['instrument'] = ','.join(data['instrument'])
+        return data
+
     def validate(self, data):
         if data['password1'] != data['password2']:
             raise serializers.ValidationError('비밀번호가 일치하지 않습니다.')
         return data
 
     def create(self, validated_data):
-        user = User(
+        return User.objects.create_user(
             email=validated_data['email'],
             nickname=validated_data['nickname'],
             instrument=validated_data['instrument'],
         )
-        user.set_password(validated_data['password1'],)
-        user.save()
-        return user


### PR DESCRIPTION
<models.py>
user model 수정
- instrument 필드 여러 악기를 받을 수 있게 수정 ('drum,keyboard,ukulele' 와 같은 문자열로 저장)
- is_staff, is_superuser = False 기본값 설정
- activation_key 추가 (이메일 인증에 사용될 해쉬)

<serializer.py>
User = get_user_model() 사용

SignupSerializer 수정
- create 함수에 `User.objects.create_user` 사용
- validate_instrument 추가